### PR TITLE
Change: remove `args=` parameter

### DIFF
--- a/src/backend/helper.py
+++ b/src/backend/helper.py
@@ -2,6 +2,12 @@
 General helper functions
 """
 
+def query_to_args_list(query):
+    """
+    Convert query string to a list of arguments.
+    """
+    args = [query] if query else []
+    return args
 
 def seperate_args(args):
     """

--- a/src/backend/server.py
+++ b/src/backend/server.py
@@ -7,6 +7,7 @@ import http.server
 import subprocess
 from urllib.parse import urlparse, parse_qs
 from dotenv import load_dotenv
+from helper import query_to_args_list
 
 # Load environment variables from .env file
 load_dotenv(override=True)
@@ -29,10 +30,9 @@ class MyHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
         """
         # Parse the query parameters
         parsed_url = urlparse(self.path)
-        query_params = parse_qs(parsed_url.query)
 
         # Extract the arguments from the query parameters
-        args = query_params.get("args", [])
+        args = query_to_args_list(parsed_url.query)
 
         if "help" in args:
             # If 'help' is in the args, read and return the content of help.txt

--- a/src/tests/test_code.py
+++ b/src/tests/test_code.py
@@ -13,8 +13,24 @@ from unittest.mock import patch
 import io
 import time
 from main import main
-from helper import extract_decimal
+from helper import extract_decimal, query_to_args_list
 from api import get_coordinates, get_uv, ocean_information
+
+
+def test_query_to_args_list_with_non_empty_params():
+    """
+    Test if query_to_args_list function correctly converts non-empty query parameters to a list.
+    """
+    args = query_to_args_list("location=new_york,hide_height,show_large_wave")
+    assert args == ["location=new_york,hide_height,show_large_wave"]
+
+
+def test_query_to_args_list_with_empty_params():
+    """
+    Test if query_to_args_list function correctly handles empty query parameters and returns an empty list.
+    """
+    args = query_to_args_list("")
+    assert args == []
 
 
 def test_invalid_input():


### PR DESCRIPTION
@ryansurf 

The changes are as follows:

- Update `server.py` to use the new `query_to_args_list` function from `helper.py` instead of the `parse_qs` function
  - The `query_to_args_list` function is a simple function that stores a string as a list
  - The previously used `parse_qs` function converts query parameters into a dictionary format. Since the purpose of this change is to deprecate `args=` and store the single string specified in the query parameters as a list, the `parse_qs` function is no longer used.
- Add test code for the `query_to_args_list` function

Also, I believe that the README.md file needs to be updated to reflect these changes, but before proceeding with that, could you please review the changes and confirm if there are any issues with the current implementation?

Fixes #7