### PR TITLE
Refactor index.html rendering and variable passing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+PORT=8000
+IP_ADDRESS="localhost"
 SMTP_SERVER ='smtp.gmail.com'
 EMAIL=your-email
 EMAIL_PW=email-password

--- a/config.json
+++ b/config.json
@@ -1,6 +1,0 @@
-{
-    "server": {
-        "port" : 8000,
-        "ip_address" : "localhost"
-    }
-}

--- a/src/backend/helper.py
+++ b/src/backend/helper.py
@@ -33,12 +33,6 @@ def arguments_dictionary(lat, long, city, args):
     }
     return arguments
 
-def query_to_args_list(query):
-    """
-    Convert query string to a list of arguments.
-    """
-    args = [query] if query else []
-    return args
 
 def seperate_args(args):
     """

--- a/src/backend/server.py
+++ b/src/backend/server.py
@@ -2,42 +2,44 @@
 Flask Server!
 """
 
-from flask import Flask, send_file, send_from_directory, request
+from flask import Flask, send_file, send_from_directory, request, render_template
 from flask_cors import CORS
+from dotenv import load_dotenv
+import os
 import subprocess
 import json
-import helper
-import sys
 import asyncio
 import urllib.parse
+
+# Load environment variables from .env file
+load_dotenv(override=True)
 
 app = Flask(__name__)
 CORS(app)
 
-with open('../../config.json') as f:
-    json_config = json.load(f)
 
-port_json = int(json_config["server"]["port"])
-
-@app.route('/config.json')
-def serve_config():
-    return send_from_directory('../../', 'config.json')
-
-@app.route('/help')
+@app.route("/help")
 def serve_help():
-    return send_from_directory('../../', 'help.txt')
+    return send_from_directory("../../", "help.txt")
 
-@app.route('/home')
+
+@app.route("/home")
 def serve_index():
-    return send_file('../frontend/index.html')
+    return render_template(
+        "index.html", port=os.getenv("PORT"), ip_address=os.getenv("IP_ADDRESS")
+    )
 
-@app.route('/script.js')
+
+@app.route("/script.js")
 def serve_script():
-    return send_file('../frontend/script.js')
+    return send_file("../frontend/script.js")
 
-@app.route('/')
+
+@app.route("/")
 def default_route():
-    query_parameters = urllib.parse.parse_qsl(request.query_string.decode(), keep_blank_values=True)
+    query_parameters = urllib.parse.parse_qsl(
+        request.query_string.decode(), keep_blank_values=True
+    )
     parsed_parameters = []
 
     for key, value in query_parameters:
@@ -47,7 +49,7 @@ def default_route():
             parsed_parameters.append(key)
 
     # Join the parsed parameters list into a single string
-    args = ','.join(parsed_parameters)
+    args = ",".join(parsed_parameters)
 
     async def run_subprocess():
         try:
@@ -70,5 +72,6 @@ def default_route():
     result = loop.run_until_complete(run_subprocess())
     return result
 
-if __name__ == '__main__':
-    app.run(port=port_json)
+
+if __name__ == "__main__":
+    app.run(port=os.getenv("PORT"))

--- a/src/backend/server.py
+++ b/src/backend/server.py
@@ -4,7 +4,7 @@ Flask Server!
 
 from flask import Flask, send_file, send_from_directory, request, render_template
 from flask_cors import CORS
-from dotenv import load_dotenv
+from dotenv import load_dotenv, dotenv_values
 import os
 import subprocess
 import json
@@ -25,9 +25,7 @@ def serve_help():
 
 @app.route("/home")
 def serve_index():
-    return render_template(
-        "index.html", port=os.getenv("PORT"), ip_address=os.getenv("IP_ADDRESS")
-    )
+    return render_template("index.html", env_vars=dict(dotenv_values()))
 
 
 @app.route("/script.js")

--- a/src/backend/templates/index.html
+++ b/src/backend/templates/index.html
@@ -76,6 +76,11 @@
         </div>
       </div>
     </div>
-    <script src="script.js"></script>
+    <script>
+      // variables
+      const ipAddress = '{{ ip_address }}';
+      const port = '{{ port }}';
+    </script>
+    <script src="{{ url_for('serve_script') }}"></script>
   </body>
 </html>

--- a/src/backend/templates/index.html
+++ b/src/backend/templates/index.html
@@ -77,9 +77,8 @@
       </div>
     </div>
     <script>
-      // variables
-      const ipAddress = '{{ ip_address }}';
-      const port = '{{ port }}';
+      // load .env variables from Flask server
+      const env = {{ env_vars|tojson }};
     </script>
     <script src="{{ url_for('serve_script') }}"></script>
   </body>

--- a/src/frontend/script.js
+++ b/src/frontend/script.js
@@ -1,29 +1,3 @@
-// ipAddress = the ip of the machine that is hosting the server
-
-let port;
-let ipAddress;
-
-fetch('/config.json', {
-    method: 'GET',
-    mode: 'no-cors',  // Add the 'no-cors' mode
-  })
-.then(response => {
-  if (!response.ok) {
-    throw new Error(`HTTP error! Status: ${response.status}`);
-  }
-  return response.json();
-})
-.then(config => {
-  // Pass the config to another function if needed
-  useConfig(config);
-})
-.catch(error => console.error('Error loading config:', error));
-
-function useConfig(config) {
-    port = config["server"]["port"];
-    ipAddress = config["server"]["ip_address"];
-}
-
 const cancelbutton = document.getElementById("cancel");
 cancelbutton.addEventListener("click",function(){
     document.getElementById("curlInput").value =""; 

--- a/src/frontend/script.js
+++ b/src/frontend/script.js
@@ -20,7 +20,7 @@ document.getElementById("reportForm").addEventListener("submit", function(event)
     }
 
     // Construct the URL with the location query parameter
-    var url = `http://${ipAddress}:${port}?location=${encodeURIComponent(location)}`;
+    var url = `http://${env.IP_ADDRESS}:${env.PORT}?location=${encodeURIComponent(location)}`;
     console.log(url);
 
     // Call httpGetAsync with the URL and the handleResponse function as parameters
@@ -47,7 +47,7 @@ document.addEventListener("submit", function() {
         // Get the value of the location input field
         var location = document.getElementById("curlInput").value;
         location = location.replace(/\s+/g, "_");
-        fetch(`http://${ipAddress}:${port}?location=${encodeURIComponent(location)}`)
+        fetch(`http://${env.IP_ADDRESS}:${env.PORT}?location=${encodeURIComponent(location)}`)
             .then(response => response.text())
             .then(data => {
                 // Parse the response text to extract the desired information

--- a/src/tests/test_code.py
+++ b/src/tests/test_code.py
@@ -12,24 +12,8 @@ from unittest.mock import patch
 import io
 import time
 from main import main
-from helper import extract_decimal, query_to_args_list
+from helper import extract_decimal
 from api import get_coordinates, get_uv, ocean_information
-
-
-def test_query_to_args_list_with_non_empty_params():
-    """
-    Test if query_to_args_list function correctly converts non-empty query parameters to a list.
-    """
-    args = query_to_args_list("location=new_york,hide_height,show_large_wave")
-    assert args == ["location=new_york,hide_height,show_large_wave"]
-
-
-def test_query_to_args_list_with_empty_params():
-    """
-    Test if query_to_args_list function correctly handles empty query parameters and returns an empty list.
-    """
-    args = query_to_args_list("")
-    assert args == []
 
 
 def test_invalid_input():


### PR DESCRIPTION
### The main changes include:

- Refactor the Flask route to use `render_template` instead of directly sending the `index.html` file. This enables the use of Jinja2 templating to pass environment variables from Flask to the frontend.
- Modify `index.html` to utilize the passed environment variables using Jinja2 syntax. The variables can now be accessed and used within the HTML file.
- Adjust the location of `index.html` to match the Flask project structure. The file has been moved to the appropriate folder (e.g., templates/) to work seamlessly with `render_template`.

### Refactoring
In this commit, the `query_to_args_list` function and its associated test code, which were added in #14 , have been removed due to the migration to Flask. These are no longer needed.

---

### What I'd like to discuss
Moving `index.html` to the templates folder has blurred the boundary between backend and frontend. (With this modification, the frontend folder only contains `script.js`)
If we plan to continue using Flask's template engine, I think it would be better to unify the frontend and backend directories as follows.

**Specifically**

- Remove the `backend/frontend` directories and move all the files under them directly under the src directory
- Rename what was originally the `frontend` directory to `static`
  - This is a directory name conventionally used when working with Flask.
- The directory structure I consider good 
```bash
src
├── api.py
├── art.py
├── helper.py
├── main.py
├── send_email.py
├── server.py
├── templates
│ └── index.html
├── static
│ └── script.js
└── tests
  └── test_code.py
```

Fixes #15