### PR TITLE
Move tests directory outside of src

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,5 +20,4 @@ jobs:
         pip install pytest
     - name: Test with pytest
       run: |
-        cd src
         pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+# pytest settings
+[tool.pytest.ini_options]
+pythonpath = "."
+addopts = '-p no:warnings'  # disable pytest warnings

--- a/src/api.py
+++ b/src/api.py
@@ -8,7 +8,7 @@ import requests_cache
 from retry_requests import retry
 import requests
 import pandas as pd
-import helper
+from src import helper
 
 
 def get_coordinates(args):

--- a/src/helper.py
+++ b/src/helper.py
@@ -3,8 +3,8 @@ General helper functions
 """
 
 import json
-import api
-import art
+from src import api
+from src import art
 import pandas as pd
 
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -5,9 +5,6 @@ Run pytest: pytest
 """
 
 import sys
-
-sys.path.append("../src")
-
 from unittest.mock import patch
 import io
 import time


### PR DESCRIPTION
@ryansurf 

It felt strange to have the test file inside the `src` directory, which is the execution service. So I moved it outside.
I should have noticed that yesterday... I'm sorry for the multiple requests, but could you please review the PR again!

- Relocate the tests directory to the project root level
- Update import paths in test files to reflect the new directory structure
  - Convert all relative imports to absolute imports for clarity and consistency
- Adjust configuration files (`pyproject.toml`) to match the new location
- Modify CI/CD pipeline configuration to use the updated tests directory path

This change separates the tests from the source code, following the common practice of keeping tests in a separate top-level directory.