### PR TITLE
Refactor Use `pydantic-settings` for env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 PORT=8000
 IP_ADDRESS="localhost"
-SMTP_SERVER ='smtp.gmail.com'
-EMAIL=your-email
-EMAIL_PW=email-password
-EMAIL_RECEIVER=email-to-receive-surf-report
-COMMAND=localhost:8000
-SUBJECT='Surf Report'
+SMTP_SERVER="smtp.gmail.com"
+SMTP_PORT=587
+EMAIL="your-email"
+EMAIL_PW="email-password"
+EMAIL_RECEIVER="email-to-receive-surf-report"
+COMMAND="localhost:8000"
+SUBJECT="Surf Report"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black
-    - name: Lint with black
+        pip install -r dev-requirements.txt
+    - name: Lint with ruff
       run: |
-        black .
+        make lint
+        make format

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest
+        pip install -r dev-requirements.txt
     - name: Test with pytest
       run: |
-        pytest
+        set -o pipefail
+        python -m pytest --junitxml=pytest.xml --cov-report=term-missing --cov=src tests/ | tee pytest-coverage.txt
+    - name: Pytest coverage comment
+      uses: MishaKav/pytest-coverage-comment@v1.1.47
+      with:
+        pytest-coverage-path: ./pytest-coverage.txt
+        junitxml-path: ./pytest.xml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,9 @@
 name: Pytest
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on: [push, pull_request]
 
 jobs:
@@ -13,15 +17,18 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
+
     - name: Test with pytest
       run: |
         set -o pipefail
         python -m pytest --junitxml=pytest.xml --cov-report=term-missing --cov=src tests/ | tee pytest-coverage.txt
+
     - name: Pytest coverage comment
       uses: MishaKav/pytest-coverage-comment@v1.1.47
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,8 +1,6 @@
 name: Pytest
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: write-all
 
 on: [push, pull_request]
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,7 @@ jobs:
         python -m pytest --junitxml=pytest.xml --cov-report=term-missing --cov=src tests/ | tee pytest-coverage.txt
 
     - name: Pytest coverage comment
+      continue-on-error: true
       uses: MishaKav/pytest-coverage-comment@v1.1.47
       with:
         pytest-coverage-path: ./pytest-coverage.txt

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,8 @@
 name: Pytest
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 on: [push, pull_request]
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+ruff==0.4.6
+pytest==8.2.1
+pytest-cov==5.0.0

--- a/makefile
+++ b/makefile
@@ -1,0 +1,13 @@
+.PHONY: lint format
+
+lint:
+	ruff check . && ruff check . --diff
+
+format:
+	ruff check . --fix && ruff format .
+
+test:
+	pytest -s -x --cov=src -vv
+
+post_test:
+	coverage html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,23 @@
 [tool.pytest.ini_options]
 pythonpath = "."
 addopts = '-p no:warnings'  # disable pytest warnings
+
+# ruff global settings
+[tool.ruff]
+line-length = 79
+
+# linter
+[tool.ruff.lint]
+# I: isort
+# F: Pyflakes
+# E: Pycodestyle Error
+# W: Pycodestyle Warning
+# P: Pylint
+# PT: flake8-pytest-style
+preview = true
+select = ['I', 'F', 'E', 'W', 'PL', 'PT']
+
+# formatter
+[tool.ruff.format]
+preview = true
+quote-style = 'double'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ python-dotenv==1.0.1
 Requests==2.32.2
 requests_cache==1.2.0
 retry_requests==2.0.0
+pydantic==2.7.1
+pydantic-settings==2.2.1
+email-validator==2.1.1

--- a/src/api.py
+++ b/src/api.py
@@ -2,12 +2,15 @@
 Functions that make API calls stored here
 """
 
-from geopy.geocoders import Nominatim
+from http import HTTPStatus
+
 import openmeteo_requests
-import requests_cache
-from retry_requests import retry
-import requests
 import pandas as pd
+import requests
+import requests_cache
+from geopy.geocoders import Nominatim
+from retry_requests import retry
+
 from src import helper
 
 
@@ -17,8 +20,8 @@ def get_coordinates(args):
     If no location is specified, default_location() finds the users coordinates
     """
     for arg in args:
-        arg = str(arg)
-        if arg.startswith("location=") or arg.startswith("loc="):
+        arg_str = str(arg)
+        if arg_str.startswith("location=") or arg_str.startswith("loc="):
             address = arg.split("=")[1]
             geolocator = Nominatim(user_agent="cli-surf")
             location = geolocator.geocode(address)
@@ -35,7 +38,7 @@ def default_location():
     """
     response = requests.get("https://ipinfo.io/json", timeout=10)
 
-    if response.status_code == 200:
+    if response.status_code == HTTPStatus.OK:
         data = response.json()
         location = data["loc"].split(",")
         lat = location[0]
@@ -98,7 +101,8 @@ def ocean_information(lat, long, decimal, unit="imperial"):
     except ValueError:
         return "No data"
 
-    # Process first location. Add a for-loop for multiple locations or weather models
+    # Process first location.
+    # Add a for-loop for multiple locations or weather models
     response = responses[0]
 
     # Current values. The order of variables needs to be the same as requested.
@@ -125,7 +129,11 @@ def forecast(lat, long, decimal, days=0):
     params = {
         "latitude": lat,
         "longitude": long,
-        "daily": ["wave_height_max", "wave_direction_dominant", "wave_period_max"],
+        "daily": [
+            "wave_height_max",
+            "wave_direction_dominant",
+            "wave_period_max",
+        ],
         "length_unit": "imperial",
         "timezone": "auto",
         "forecast_days": days,

--- a/src/art.py
+++ b/src/art.py
@@ -24,13 +24,12 @@ def print_wave(show_wave, show_large_wave, color):
         print("Not a valid color")
         color = "blue"
     if int(show_wave) == 1:
-
         print(
             colors[color]
             + """
       .-``'.
     .`   .`
-_.-'     '._ 
+_.-'     '._
         """
             + colors["end"]
         )

--- a/src/cli.py
+++ b/src/cli.py
@@ -2,14 +2,12 @@
 Main module
 """
 
-import sys
 import os
+import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from src import helper
-from src import api
-from src import art
+from src import api, helper
 
 
 def run(lat=0, long=0):
@@ -39,7 +37,7 @@ def run(lat=0, long=0):
     # Makes calls to the apis(ocean, UV) and returns the values
     data = api.gather_data(lat, long, arguments)
     ocean_data = data[0]
-    uv_index = data[1]
+    # uv_index = data[1]
     data_dict = data[2]
 
     # Non-JSON output

--- a/src/cli.py
+++ b/src/cli.py
@@ -2,10 +2,10 @@
 Main module
 """
 
-import os
 import sys
+from pathlib import Path
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).parent.parent))
 
 from src import api, helper
 

--- a/src/helper.py
+++ b/src/helper.py
@@ -3,9 +3,8 @@ General helper functions
 """
 
 import json
-from src import api
-from src import art
-import pandas as pd
+
+from src import api, art
 
 
 def arguments_dictionary(lat, long, city, args):
@@ -47,11 +46,12 @@ def get_forecast_days(args):
     """
     Checks to see if forecast in cli args. Defaults to 0
     """
+    MAX_VALUE = 7
     for arg in args:
-        arg = str(arg)
-        if arg.startswith("forecast=") or arg.startswith("fc="):
-            forecast = int(arg.split("=")[1])
-            if forecast < 0 or forecast > 7:
+        arg_str = str(arg)
+        if arg_str.startswith("forecast=") or arg_str.startswith("fc="):
+            forecast = int(arg_str.split("=")[1])
+            if forecast < 0 or forecast > MAX_VALUE:
                 print("Must choose a non-negative number >= 7 in forecast!")
                 break
             return forecast
@@ -67,7 +67,6 @@ def print_location(city, show_city):
         print("\n")
 
 
-# def print_output(uv_index, ocean_data, show_uv, show_height, show_direction, show_period):
 def print_output(ocean_data_dict):
     """
     Prints output
@@ -119,9 +118,9 @@ def get_color(args):
     Gets the color in the cli args
     """
     for arg in args:
-        arg = str(arg)
-        if arg.startswith("color=") or arg.startswith("c="):
-            color_name = arg.split("=")[1]
+        arg_str = str(arg)
+        if arg_str.startswith("color=") or arg_str.startswith("c="):
+            color_name = arg_str.split("=")[1]
             return color_name
     return "blue"
 
@@ -138,7 +137,8 @@ def round_decimal(round_list, decimal):
 
 def set_output_values(args, ocean):
     """
-    Takes a list of command line arguments(args) and sets the appropritate values
+    Takes a list of command line arguments(args)
+    and sets the appropritate values
     in the ocean dictionary(show_wave = 1, etc)
     """
     if "hide_wave" in args or "hw" in args:
@@ -175,7 +175,8 @@ def json_output(data_dict):
 
 def print_outputs(lat, long, coordinates, ocean_data, arguments):
     """
-    Basically the main printing function, calls all the other printing functions
+    Basically the main printing function,
+    calls all the other printing functions
     """
     print("\n")
     if coordinates == "No data":
@@ -186,11 +187,15 @@ def print_outputs(lat, long, coordinates, ocean_data, arguments):
     else:
         print_location(arguments["city"], arguments["show_city"])
         art.print_wave(
-            arguments["show_wave"], arguments["show_large_wave"], arguments["color"]
+            arguments["show_wave"],
+            arguments["show_large_wave"],
+            arguments["color"],
         )
         print_output(arguments)
     print("\n")
-    forecast = api.forecast(lat, long, arguments["decimal"], arguments["forecast_days"])
+    forecast = api.forecast(
+        lat, long, arguments["decimal"], arguments["forecast_days"]
+    )
     print_forecast(arguments, forecast)
 
 

--- a/src/send_email.py
+++ b/src/send_email.py
@@ -3,10 +3,11 @@ Module to send surf report emails
 """
 
 import os
-import subprocess
 import smtplib
-from email.mime.text import MIMEText
+import subprocess
 from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -35,7 +36,10 @@ def send_user_email():
     Sends user an email
     """
     SURF = subprocess.run(
-        ["curl", os.getenv("COMMAND")], capture_output=True, text=True, check=True
+        ["curl", os.getenv("COMMAND")],
+        capture_output=True,
+        text=True,
+        check=True,
     )
     if SURF.returncode == 0:  # Check if command executed successfully
         BODY = SURF.stdout

--- a/src/send_email.py
+++ b/src/send_email.py
@@ -2,33 +2,21 @@
 Module to send surf report emails
 """
 
-import os
 import smtplib
 import subprocess
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-from dotenv import load_dotenv
+from settings import EmailSettings
 
 # Load environment variables from .env file
-load_dotenv(override=True)
-
-# Email server configuration
-SMTP_SERVER = os.getenv("SMTP_SERVER")
-PORT = 587  # Port for TLS connection
-
-# Sender's email credentials
-SENDER_EMAIL = os.getenv("EMAIL")
-PASSWORD = os.getenv("EMAIL_PW")
-
-# Receiver's email
-RECEIVER_EMAIL = os.getenv("EMAIL_RECEIVER")
+env = EmailSettings()
 
 # Create a multipart message and set headers
 message = MIMEMultipart()
-message["From"] = SENDER_EMAIL
-message["To"] = RECEIVER_EMAIL
-message["Subject"] = os.getenv("SUBJECT")
+message["From"] = env.EMAIL
+message["To"] = env.EMAIL_RECEIVER
+message["Subject"] = env.SUBJECT
 
 
 def send_user_email():
@@ -36,7 +24,7 @@ def send_user_email():
     Sends user an email
     """
     SURF = subprocess.run(
-        ["curl", os.getenv("COMMAND")],
+        ["curl", env.COMMAND],
         capture_output=True,
         text=True,
         check=True,
@@ -48,12 +36,12 @@ def send_user_email():
     message.attach(MIMEText(BODY, "plain"))
 
     # Connect to the SMTP server
-    with smtplib.SMTP(SMTP_SERVER, PORT) as server:
+    with smtplib.SMTP(env.SMTP_SERVER, env.SMTP_PORT) as server:
         server.starttls()  # Secure the connection
-        server.login(SENDER_EMAIL, PASSWORD)
+        server.login(env.EMAIL, env.EMAIL_PW)
         text = message.as_string()
-        server.sendmail(SENDER_EMAIL, RECEIVER_EMAIL, text)
+        server.sendmail(env.EMAIL, env.EMAIL_RECEIVER, text)
         print("Email sent successfully.")
 
-
-send_user_email()
+if __name__ == "__main__":
+    send_user_email()

--- a/src/server.py
+++ b/src/server.py
@@ -2,13 +2,20 @@
 Flask Server!
 """
 
-from flask import Flask, send_file, send_from_directory, request, render_template
-from flask_cors import CORS
-from dotenv import load_dotenv, dotenv_values
+import asyncio
 import os
 import subprocess
-import asyncio
 import urllib.parse
+
+from dotenv import dotenv_values, load_dotenv
+from flask import (
+    Flask,
+    render_template,
+    request,
+    send_file,
+    send_from_directory,
+)
+from flask_cors import CORS
 
 # Load environment variables from .env file
 load_dotenv(override=True)

--- a/src/server.py
+++ b/src/server.py
@@ -3,11 +3,10 @@ Flask Server!
 """
 
 import asyncio
-import os
 import subprocess
 import urllib.parse
 
-from dotenv import dotenv_values, load_dotenv
+from pathlib import Path
 from flask import (
     Flask,
     render_template,
@@ -17,8 +16,10 @@ from flask import (
 )
 from flask_cors import CORS
 
+from settings import ServerSettings
+
 # Load environment variables from .env file
-load_dotenv(override=True)
+env = ServerSettings()
 
 app = Flask(__name__)
 CORS(app)
@@ -26,12 +27,14 @@ CORS(app)
 
 @app.route("/help")
 def serve_help():
-    return send_from_directory("../", "help.txt")
+    return send_from_directory(
+        f"{str(Path(__file__).parent)}/", "help.txt"
+    )
 
 
 @app.route("/home")
 def serve_index():
-    return render_template("index.html", env_vars=dict(dotenv_values()))
+    return render_template("index.html", env_vars=env.model_dump())
 
 
 @app.route("/script.js")
@@ -78,4 +81,4 @@ def default_route():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=os.getenv("PORT"))
+    app.run(host="0.0.0.0", port=env.PORT)

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from typing import Literal, Union
+
+from pydantic import EmailStr, Field, IPvAnyAddress
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class CommonSettings(BaseSettings):
+    """
+    Base class for defining common settings.
+    model_config (SettingsConfigDict)Configuration dictionary
+    for specifying the settings file and encoding.
+    """
+    model_config = SettingsConfigDict(
+        env_file=f"{Path(__file__).parent.parent}/.env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+
+class ServerSettings(CommonSettings):
+    """
+    Class for defining server env settings.
+    """
+
+    PORT: int = Field(default=8000)
+    IP_ADDRESS: Union[IPvAnyAddress | Literal["localhost"]] = Field(
+        default="localhost"
+    )
+
+
+class EmailSettings(ServerSettings):
+    """
+    Class for defining email env settings.
+    """
+
+    SMTP_SERVER: str = Field(default="smtp.gmail.com")  # default gmail server
+    SMTP_PORT: int = Field(default=587)  # default 587
+    EMAIL: EmailStr  # required
+    EMAIL_PW: str  # required
+    EMAIL_RECEIVER: EmailStr  # required
+    COMMAND: str = Field(
+        default_factory=lambda cls: f"{cls.IP_ADDRESS}:{cls.PORT}"
+    )
+    SUBJECT: str = Field(default="Surf Report")

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -4,13 +4,13 @@ Make sure pytest is installed: pip install pytest
 Run pytest: pytest
 """
 
-import sys
-from unittest.mock import patch
 import io
 import time
+from unittest.mock import patch
+
 from src import cli
-from src.helper import extract_decimal
 from src.api import get_coordinates, get_uv, ocean_information
+from src.helper import extract_decimal
 
 
 def test_invalid_input():
@@ -20,7 +20,8 @@ def test_invalid_input():
     with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
         extract_decimal(["decimal=NotADecimal"])
         printed_output = fake_stdout.getvalue().strip()
-        assert printed_output == "Invalid value for decimal. Please provide an integer."
+        expected = "Invalid value for decimal. Please provide an integer."
+        assert printed_output == expected
 
 
 def test_default_input():
@@ -53,9 +54,11 @@ def test_main_output():
     Main() returns a dictionary of: location, height, period, etc.
     This functions checks if the dictionary is returned and is populated
     """
-    # Hardcode lat and long for location. If not, when test are ran in Github Actions
+    # Hardcode lat and long for location.
+    # If not, when test are ran in Github Actions
     # We get an error(because server probably isn't near ocean)
+    expected = 5
     data_dict = cli.run(36.95, -121.97)
     print(data_dict)
     time.sleep(5)
-    assert len(data_dict) >= 5
+    assert len(data_dict) >= expected


### PR DESCRIPTION
@ryansurf 
Sorry for bombarding you with pull requests one after another!

I refactored the environment variable loading process (`os.getenv()`) and used [`pydantic-settings`](https://docs.pydantic.dev/latest/concepts/pydantic_settings/
) to make it type-safe!

Maybe you know, The benefits of `pydantic-settings` are:

- You can define the expected type for each environment variable using `pydantic-settings`.  When the Python script runs, it automatically validates the loaded values against the specified types.  This helps catch errors in the environment variable values early on, preventing the process from proceeding with incorrect settings.
  - If the type is wrong, it'll throw an error at runtime.

- With `pydantic-settings`, you can define all the environment variables in a centralized configuration class(`settings.py`). This makes it easier to manage and maintain the configuration settings in one place, improving code organization and readability.

Thanks to this, `send_email.py` now throws an error if the email address isn't set, for example.

I'd be stoked if you could merge this in!!

---
Also, I know this article is in Japanese, but I wanted to share a piece I wrote about `pydantic-settings`:)
https://qiita.com/inetcpl/items/b4146b9e8e1adad239d8