### PR TITLE
Introduce pre-commit and update documentation

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,5 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r dev-requirements.txt
-    - name: Lint with ruff
-      run: |
-        make lint
-        make format
+    - name: Run pre-commit
+      run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ ., --fix ]
+        args: [ ., --fix, --diff ]
       # Run the formatter.
       - id: ruff-format
         args: [ . ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ --fix ]
+        args: [ ., --fix ]
       # Run the formatter.
       - id: ruff-format
+        args: [ . ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.4.6
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,26 +15,37 @@ To find issues you can help with, go though the list of [good first issues](http
 Once you find an interesting issue let us know that you want to work on it by commenting on the issue.
 
 ## Development
+### Install our development environment
+Install the development dependencies:
+```
+pip install -r requirements.txt -r dev-requirements.txt
+```
 
-**Code Style and Quality**
+Install the `pre-commit`:
+```
+pre-commit install
+```
 
-The [PEP 8](https://realpython.com/python-pep8/) styling convention is used.
+### Code Style and Quality
+- The [PEP 8](https://realpython.com/python-pep8/) styling convention is used.
+- This is achieved using the `ruff` Linter and Formatter.
+- The Linter and Formatter are automatically executed before committing via pre-commit.
+  - If you want to run the Linter and Formatter at any time, execute `pre-commit run --all-files`.
 
-To make sure you are following it, you can install [black](https://pypi.org/project/black/)
+### Testing
+> [!NOTE]
+> This project uses `Makefile` as a task runner. You need to set up your environment to be able to run the `make` command.
 
-`pip install black`
+Run the following command in the project's root directory:
+```
+make test
+```
+You can generate a coverage report with the following command:
+```
+make post_test
+```
+Additionally, when a PR is raised, pytest will be executed by the GitHub Actions CI.
 
-To run black:
-
-`black .`
-
-**Testing**
-
-To run tests, install pytest, `pip install pytest` and navigate to `/test`.
-
-Run `pytest`
-
-On commit, git will run `pytest` for you to catch any errors.
 
 ## Questions, suggestions or new ideas
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Change `.env.example` to `.env`
 | `PORT`  | The port you want to open to run the application. Default = `8000` |
 | `IP_ADDRESS`  | The ip your server is running on. Default = `localhost` |
 | `SMTP_SERVER`  | The email server you are using. Default = smtp.gmail.com |
+| `SMTP_PORT`  | The email server port you are using. Default = `587` |
 | `EMAIL`  | The email you will send the report from. |
 | `EMAIL_PW`  | The sending email's password |
 | `EMAIL_RECEIVER`  | The email that will receive the report (your personal email) |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 ruff==0.4.6
 pytest==8.2.1
 pytest-cov==5.0.0
+pre-commit==3.7.1

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,15 +1,10 @@
 # Styling
 
 ## Code Style and Quality
-
 The [PEP 8](https://realpython.com/python-pep8/) styling convention is used.
 
-To make sure you are following it, you can install [black](https://pypi.org/project/black/)
+This is achieved using the ruff Linter and Formatter.
 
-`pip install black`
+The Linter and Formatter are automatically executed before committing via pre-commit.
 
-To run black:
-
-`black .`
-
-On a push/pull request, git will run `black .` for you!
+If you want to run the Linter and Formatter at any time, execute `pre-commit run --all-files`.

--- a/makefile
+++ b/makefile
@@ -1,10 +1,7 @@
-.PHONY: lint format
+.PHONY: run test post_test
 
-lint:
-	ruff check . && ruff check . --diff
-
-format:
-	ruff check . --fix && ruff format .
+run:
+	cd src && python3 server.py
 
 test:
 	pytest -s -x --cov=src -vv


### PR DESCRIPTION
- Configure pre-commit hooks to run ruff for linting and formatting
  - Update documentation to include pre-commit setup and usage instructions
- Remove Linter/Formatter tasks from Makefile as they are now handled by pre-commit
- Modify CI (`linter.yml`) to hook into pre-commit's Linter/Formatter

I've taken a stab at updating the documentation, but there might be some areas I've overlooked. 
If you spot anything, please let me know!

Fixes #29 