### PR TITLE
Include UV index in forecast

### DIFF
--- a/docs/structure.md
+++ b/docs/structure.md
@@ -28,9 +28,6 @@ More in-depth structure:
 .
 ├── compose.yaml
 ├── CONTRIBUTING.md
-├── dist
-│   ├── cli_surf-0.1.0-py3-none-any.whl
-│   └── cli_surf-0.1.0.tar.gz
 ├── Dockerfile
 ├── docs
 │   ├── cheat_sheet.md
@@ -76,6 +73,6 @@ More in-depth structure:
     ├── test_helper.py
     └── test_server.py
 
-10 directories, 40 files
+9 directories, 38 files
 ```
 <!-- STRUCTURE END  -->

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -28,6 +28,9 @@ More in-depth structure:
 .
 ├── compose.yaml
 ├── CONTRIBUTING.md
+├── dist
+│   ├── cli_surf-0.1.0-py3-none-any.whl
+│   └── cli_surf-0.1.0.tar.gz
 ├── Dockerfile
 ├── docs
 │   ├── cheat_sheet.md
@@ -73,6 +76,6 @@ More in-depth structure:
     ├── test_helper.py
     └── test_server.py
 
-9 directories, 38 files
+10 directories, 40 files
 ```
 <!-- STRUCTURE END  -->

--- a/src/helper.py
+++ b/src/helper.py
@@ -150,6 +150,8 @@ def print_forecast(ocean, forecast):
             print("Wave Direction: ", day[1])
         if int(ocean["show_period"]) == 1:
             print("Wave Period: ", day[2])
+        if int(ocean["show_uv"]) == 1:
+            print("UV Index: ", day[4])
         print("\n")
 
 
@@ -248,7 +250,7 @@ def forecast_to_json(data, decimal):
     """
     Takes forecast() as input and returns it in JSON format
     """
-    surf_height, swell_direction, swell_period, dates = data
+    surf_height, swell_direction, swell_period, dates, uv_index = data
 
     # Formatting into JSON
     forecasts = []
@@ -258,6 +260,7 @@ def forecast_to_json(data, decimal):
             "surf height": round(float(surf_height[i]), decimal),
             "swell direction": round(float(swell_direction[i]), decimal),
             "swell period": round(float(swell_period[i]), decimal),
+            "uv index": round(float(uv_index[i]), decimal),
         }
         forecasts.append(forecast)
 


### PR DESCRIPTION
Addresses https://github.com/ryansurf/cli-surf/issues/2

The `forecast(lat, long, decimal, days=0)` function in `api.py` now also returns a uv index forecast. The addition of the API endpoint https://api.open-meteo.com/v1/forecast enables us to grab this information (the other API endpoint was only for ocean data)

In `helper.api`, the json/print forecast functions were altered to include the uv forecast.

Please take a look at this PR whenever you are able @K-dash !