### PR TITLE
Fix: Prevent small wave from showing when large wave is displayed

### DIFF
--- a/src/art.py
+++ b/src/art.py
@@ -23,16 +23,7 @@ def print_wave(show_wave, show_large_wave, color):
     if color is not None and color.lower() not in colors:
         print("Not a valid color")
         color = "blue"
-    if int(show_wave) == 1:
-        print(
-            colors[color]
-            + """
-      .-``'.
-    .`   .`
-_.-'     '._
-        """
-            + colors["end"]
-        )
+
     if int(show_large_wave) == 1:
         print(
             colors[color]
@@ -47,5 +38,15 @@ _.-'     '._
 ⢀⣄⣠⣶⣿⠏⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠓⠚⠋⠉⠀⠀⠀⠀⠀⠀⠈⠛⡛⡻⠿⠿⠙⠓⢒⣺⡿⠋⠁
 ⠉⠉⠉⠛⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠁⠀
 """
+            + colors["end"]
+        )
+    elif int(show_wave) == 1:
+        print(
+            colors[color]
+            + """
+      .-``'.
+    .`   .`
+_.-'     '._
+        """
             + colors["end"]
         )


### PR DESCRIPTION
Fix: Prevent small wave from displaying when large wave is shown
Fixes #70 

This pull request addresses the issue where both the small and large waves were being displayed simultaneously when the large wave was requested. The changes ensure that only one wave (either large or small) is shown at a time, with priority given to the large wave when both are requested.

Changes made:
- Reordered conditional statements in the print_wave function to prioritize the large wave display
- Removed the small wave display when the large wave is shown

This fix improves the visual consistency of the wave display and aligns with the expected behavior as discussed in issue #70

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes an issue where both the small and large waves were being displayed simultaneously. The changes ensure that only one wave is shown at a time, prioritizing the large wave when both are requested. This improves the visual consistency of the wave display.

- **Bug Fixes**:
    - Ensured that the small wave is not displayed when the large wave is shown by reordering conditional statements in the print_wave function.

<!-- Generated by sourcery-ai[bot]: end summary -->