### PR TITLE
all contributors bot!

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,4 @@
+{
+  "projectName": "cli-surf",
+  "projectOwner": "ryansurf"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,14 @@ make output_coverage_docker
 ```
 Additionally, when a PR is raised, pytest will be executed by the GitHub Actions CI.
 
+## Adding youself to the contributors list
+
+On your issue/PR, simply ask the `@all-contributors` bot to add yourself!
+
+`@all-contributors please add @<username> for <contributions>`
+
+See documentation [here](https://allcontributors.org/docs/en/bot/usage)
+
 
 ## Questions, suggestions or new ideas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ make output_coverage_docker
 ```
 Additionally, when a PR is raised, pytest will be executed by the GitHub Actions CI.
 
-## Adding youself to the contributors list
+## Adding yourself to the contributors list
 
 On your issue/PR, simply ask the `@all-contributors` bot to add yourself!
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,16 @@ Questions? Comments?
 
 ## ✨ Contributors
 
-<a href="https://github.com/ryansurf/cli-surf/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=ryansurf/cli-surf" />
-</a>
+[![All Contributors](https://img.shields.io/github/all-contributors/ryansurf/cli-surf?color=ee8449&style=flat-square)](#contributors)
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 
 ## License


### PR DESCRIPTION
@K-dash https://github.com/ryansurf/cli-surf/issues/83

Setup for the all-contributors bot to work

Added instructions for how to use the bot in `CONTRIBUTING.md`

`.all-contributorsrc` is the config file, specified [here](https://allcontributors.org/docs/en/bot/installation)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Integrate the all-contributors bot to manage and display project contributors. Update `README.md` to include the all-contributors badge and placeholder for the contributors list.

Documentation:
- Added instructions in `CONTRIBUTING.md` on how to use the all-contributors bot.

Chores:
- Configured the all-contributors bot by adding `.all-contributorsrc` file.

<!-- Generated by sourcery-ai[bot]: end summary -->