### PR TITLE
use std python image instead of alpine due to build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-
-FROM python:alpine3.20
-
-# install apt packages (curl command)
-RUN apk add --update-cache curl && \
-    apk cache clean && \
-    rm -rf /var/cache/apk/*
+FROM python:3
 
 #this instruction specifies the "working directory"
 #or the path in the image where files will be copied and commands will be executed.
@@ -20,10 +14,6 @@ COPY .env.example .env
 RUN pip install poetry
 RUN poetry config installer.max-workers 10
 RUN poetry install --no-interaction --no-ansi
-
-# # Setup an app user so the container doesn't run as the root user
-# RUN useradd app
-# USER app
 
 # Set the working directory for running the application
 EXPOSE 8000


### PR DESCRIPTION
the build is 1.9g  but to be fair 0.9 of that is dependencies that are installed. 

lots of research & time, little change.  how it should be :) 

