### PR TITLE
pytest & lint status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![pytest](https://github.com/ryansurf/cli-surf/actions/workflows/pytest.yml/badge.svg)
+![linter](https://github.com/ryansurf/cli-surf/actions/workflows/linter.yml/badge.svg)
+
 <p align="center">
   <img src="./images/wave.png" height=100>
 </p>


### PR DESCRIPTION
https://github.com/ryansurf/cli-surf/issues/120

pytest & lint status badges at top of readme!

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add pytest and linter status badges to the README.md to display the current build and linting status.

Documentation:
- Added pytest and linter status badges to the top of the README.md file.

<!-- Generated by sourcery-ai[bot]: end summary -->