### PR TITLE
fix the streamlit with updated dictionary keys

### DIFF
--- a/src/streamlit_helper.py
+++ b/src/streamlit_helper.py
@@ -66,13 +66,13 @@ def graph_data(report_dict, graph_type="Height/Period :ocean:"):
         forecast["date"] for forecast in report_dict["Forecast"]
     ]
     forecasted_heights = [
-        forecast["height"] for forecast in report_dict["Forecast"]
+        forecast["surf height"] for forecast in report_dict["Forecast"]
     ]
     forecasted_periods = [
-        forecast["period"] for forecast in report_dict["Forecast"]
+        forecast["swell period"] for forecast in report_dict["Forecast"]
     ]
     forecasted_directions = [
-        forecast["direction"] for forecast in report_dict["Forecast"]
+        forecast["swell direction"] for forecast in report_dict["Forecast"]
     ]
     # table
     if graph_type == "Height/Period :ocean:" or graph_type is None:


### PR DESCRIPTION
When querying a surf report on streamlit, we get error which is because of the change in the forecast keys and streamlit_helper not reflecting the changes.

The code ensures the streamlit_helper keys match the new forecast keys.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update streamlit_helper to align with new forecast dictionary keys, fixing errors in surf report queries.

Bug Fixes:
- Fix the streamlit_helper to use updated dictionary keys for surf report forecasts, resolving errors when querying reports.

<!-- Generated by sourcery-ai[bot]: end summary -->