### PR TITLE
Use python3.10-slim to decrease docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10-slim
 
 #this instruction specifies the "working directory"
 #or the path in the image where files will be copied and commands will be executed.


### PR DESCRIPTION
 I used [python3.10-slim](https://hub.docker.com/layers/library/python/3.10-slim/images/sha256-0d15918ecae76250659ae3036ad1fc898f801f6cb803860bdf0cc4b27fe316dc) as the base docker image according to  #113 . 
I also notice #53 and found [python-slim](https://hub.docker.com/layers/library/python/slim/images/sha256-f3a12d3da806181f09987946869cb1171c6513f877f4db08ead679018cdd2b0f?context=explore) currently has vulnerabilities. That's the reason I choose python3.10-slim.
The current docker image decreased from  1.9GB to 1.02GB.

