### PR TITLE
added tests for round_decimal, get_forecast_days, and print_location

### DIFF
--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -143,8 +143,25 @@ def test_set_output_values_combined_arguments():
     assert result == expected
 
 def test_round_decimal():
+    # Standard rounding
     rounded = helper.round_decimal([2.4345, 30.2789], 2)
     assert rounded == [2.43, 30.28]
+
+    # Empty input
+    assert helper.round_decimal([], 2) == []
+
+    # Rounding to zero decimals
+    assert helper.round_decimal([2.5, 3.7, -1.2], 0) == [2.0, 4.0, -1.0]
+
+    # Midpoint values
+    assert helper.round_decimal([2.5], 0) == [2.0] or helper.round_decimal([2.5], 0) == [3.0]  # Depending on rounding method
+    assert helper.round_decimal([2.45], 1) == [2.4] or helper.round_decimal([2.45], 1) == [2.5]  # Depending on rounding method
+
+    # Negative numbers
+    assert helper.round_decimal([-2.555, -3.444], 2) == [-2.56, -3.44]
+
+    # Integer inputs
+    assert helper.round_decimal([1, 2, 3], 2) == [1.0, 2.0, 3.0]
 
 def test_print_location_show_city_false():
     with patch("sys.stdout", new=io.StringIO()) as fake_stdout:

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -125,6 +125,7 @@ def test_set_output_values_hide_period_history():
     result = set_output_values(args, arguments_dictionary)
     assert result == expected
 
+
 def test_set_output_values_combined_arguments():
     args = [
         "show_past_uv",
@@ -142,6 +143,7 @@ def test_set_output_values_combined_arguments():
     result = set_output_values(args, arguments_dictionary)
     assert result == expected
 
+
 def test_round_decimal():
     # Standard rounding
     rounded = helper.round_decimal([2.4345, 30.2789], 2)
@@ -154,8 +156,10 @@ def test_round_decimal():
     assert helper.round_decimal([2.5, 3.7, -1.2], 0) == [2.0, 4.0, -1.0]
 
     # Midpoint values
-    assert helper.round_decimal([2.5], 0) == [2.0] or helper.round_decimal([2.5], 0) == [3.0]  # Depending on rounding method
-    assert helper.round_decimal([2.45], 1) == [2.4] or helper.round_decimal([2.45], 1) == [2.5]  # Depending on rounding method
+    # Depending on rounding method
+    assert helper.round_decimal([2.5], 0) in ([2.0], [3.0])
+    # Depending on rounding method
+    assert helper.round_decimal([2.45], 1) in ([2.4], [2.5])
 
     # Negative numbers
     assert helper.round_decimal([-2.555, -3.444], 2) == [-2.56, -3.44]
@@ -163,15 +167,19 @@ def test_round_decimal():
     # Integer inputs
     assert helper.round_decimal([1, 2, 3], 2) == [1.0, 2.0, 3.0]
 
+
 def test_print_location_show_city_false():
     with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
         helper.print_location("Not a City", 0)
         output = fake_stdout.getvalue()
-        assert output.strip() == ""
+        assert not output.strip()
+
 
 def test_get_forecast_days_valid():
+    FORECAST_DAYS = 3
     args = ["forecast=3"]
-    assert helper.get_forecast_days(args) == 3
+    assert helper.get_forecast_days(args) == FORECAST_DAYS
+
 
 def test_get_forecast_days_default():
     assert helper.get_forecast_days([]) == 0

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -125,7 +125,6 @@ def test_set_output_values_hide_period_history():
     result = set_output_values(args, arguments_dictionary)
     assert result == expected
 
-
 def test_set_output_values_combined_arguments():
     args = [
         "show_past_uv",
@@ -142,3 +141,20 @@ def test_set_output_values_combined_arguments():
     }
     result = set_output_values(args, arguments_dictionary)
     assert result == expected
+
+def test_round_decimal():
+    rounded = helper.round_decimal([2.4345, 30.2789], 2)
+    assert rounded == [2.43, 30.28]
+
+def test_print_location_show_city_false():
+    with patch("sys.stdout", new=io.StringIO()) as fake_stdout:
+        helper.print_location("Not a City", 0)
+        output = fake_stdout.getvalue()
+        assert output.strip() == ""
+
+def test_get_forecast_days_valid():
+    args = ["forecast=3"]
+    assert helper.get_forecast_days(args) == 3
+
+def test_get_forecast_days_default():
+    assert helper.get_forecast_days([]) == 0


### PR DESCRIPTION
General:

Added tests for some untested helper functions, round_decimal, print_location, and get_forecast_days. Tests for  accuracy of round_decimal, validity of get_forecast_days, error handling for print_location and get_forecast_days. 

* [Y] Have you followed the guidelines in our [Contributing](https://github.com/ryansurf/cli-surf/blob/main/CONTRIBUTING.md) document?
* [Y] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ryansurf/cli-surf/pulls) for the same update/change?

### Code:

1. [Y ] Does your submission pass [tests](https://ryansurf.github.io/cli-surf/tests/)?
2. [Y] Have you run the [linter/formatter](https://ryansurf.github.io/cli-surf/styling/) on your code locally before submission?
4. [Y] Have you added an explanation of what your changes do?
5. [Y ] Have you written new tests for your changes, as applicable?

@all-contributors please add @kimmustcode for adding tests

## Summary by Sourcery

Add unit tests for round_decimal, get_forecast_days, and print_location helper functions to improve coverage and validate their behavior

Tests:
- Add unit test for round_decimal to verify rounding to a specified precision
- Add tests for get_forecast_days to validate parsing of forecast parameter and default fallback
- Add test for print_location to ensure no output is produced when city display is disabled