### PR TITLE
remove bad practice testing

### DIFF
--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -4,7 +4,6 @@ Make sure pytest is installed: pip install pytest
 Run pytest: pytest
 """
 
-from src import gpt
 
 # // TODO: mock this api call, bad practice to actually make a call
 # commenting out because this is breaking the ci/cd pipeline

--- a/tests/test_gpt.py
+++ b/tests/test_gpt.py
@@ -6,38 +6,40 @@ Run pytest: pytest
 
 from src import gpt
 
+# // TODO: mock this api call, bad practice to actually make a call
+# commenting out because this is breaking the ci/cd pipeline
 
-def test_simple_gpt():
-    """
-    Testing the simple_gpt function
-    Calls the simple gpt and asks it to output
-    the days of the week. If the output does not contain
-    any day of the week, we assume the gpt is non-fucntional
-    """
+# def test_simple_gpt():
+#     """
+#     Testing the simple_gpt function
+#     Calls the simple gpt and asks it to output
+#     the days of the week. If the output does not contain
+#     any day of the week, we assume the gpt is non-fucntional
+#     """
 
-    surf_summary = ""
-    gpt_prompt = """Please output the days of the week in English. What day
-        is your favorite?"""
+#     surf_summary = ""
+#     gpt_prompt = """Please output the days of the week in English. What day
+#         is your favorite?"""
 
-    gpt_response = gpt.simple_gpt(surf_summary, gpt_prompt).lower()
-    expected_response = set([
-        "monday",
-        "tuesday",
-        "wednesday",
-        "thursday",
-        "friday" "saturday",
-        "sunday",
-        "一",
-        "二",
-        "三",
-        "四",
-        "五",
-    ])
+#     gpt_response = gpt.simple_gpt(surf_summary, gpt_prompt).lower()
+#     expected_response = set([
+#         "monday",
+#         "tuesday",
+#         "wednesday",
+#         "thursday",
+#         "friday" "saturday",
+#         "sunday",
+#         "一",
+#         "二",
+#         "三",
+#         "四",
+#         "五",
+#     ])
 
-    # Can case the "gpt_response" string into a list, and
-    # check for set intersection with the expected response set
-    gpt_response_set = set(gpt_response.split())
+#     # Can case the "gpt_response" string into a list, and
+#     # check for set intersection with the expected response set
+#     gpt_response_set = set(gpt_response.split())
 
-    assert gpt_response_set.intersection(
-        expected_response
-    ), f"Expected '{expected_response}', but got: {gpt_response}"
+#     assert gpt_response_set.intersection(
+#         expected_response
+#     ), f"Expected '{expected_response}', but got: {gpt_response}"


### PR DESCRIPTION
General:

removal of a test that acutally makes an api call - bad practice and breaking the ci/cd pipeline

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/ryansurf/cli-surf/blob/main/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ryansurf/cli-surf/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Code:

1. [ ] Does your submission pass [tests](https://ryansurf.github.io/cli-surf/tests/)?
2. [ ] Have you run the [linter/formatter](https://ryansurf.github.io/cli-surf/styling/) on your code locally before submission?
3. [ ] Have you updated the documentation/README to reflect your changes, as applicable?
4. [ ] Have you added an explanation of what your changes do?
5. [ ] Have you written new tests for your changes, as applicable?

## Summary by Sourcery

Remove test_simple_gpt from tests/test_gpt.py to prevent live GPT API calls and CI failures, adding a TODO to mock the call instead.

CI:
- Fix CI pipeline by removing a test that performs an external API call

Tests:
- Comment out the test_simple_gpt function in test_gpt.py to avoid making real API requests