### PR TITLE
Fix incorrect function call in ocean_information_history_invalid_coordinates test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -176,7 +176,7 @@ def test_ocean_information_history_invalid_coordinates():
     when provided with latitude and longitude values that are out of range.
     """
     with pytest.raises(OpenMeteoRequestsError):
-        get_uv_history(1000, -2000, 2)
+        ocean_information_history(1000, -2000, 2)
 
 
 def test_ocean_information_history_response_format():


### PR DESCRIPTION
General:
This PR corrects a small error in the test file tests/test_api.py, where get_uv_history() was called instead of ocean_information_history() in test_ocean_information_history_invalid_coordinates().
The change ensures that the test now properly verifies invalid coordinate handling for ocean_information_history().


* [✓] Have you followed the guidelines in our [Contributing](https://github.com/ryansurf/cli-surf/blob/main/CONTRIBUTING.md) document?
* [ ✓] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ryansurf/cli-surf/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Code:

1. [✓ ] Does your submission pass [tests](https://ryansurf.github.io/cli-surf/tests/)?
2. [✓ ] Have you run the [linter/formatter](https://ryansurf.github.io/cli-surf/styling/) on your code locally before submission?
3. [X ] Have you updated the documentation/README to reflect your changes, as applicable?
4. [ ✓] Have you added an explanation of what your changes do?
5. [✓ ] Have you written new tests for your changes, as applicable?

## Summary by Sourcery

Tests:
- Correct the test to call ocean_information_history instead of get_uv_history for invalid coordinates