### PR TITLE
Add pytest coverage for help endpoint (and root)

### DIFF
--- a/tests/test_help_endpoint.py
+++ b/tests/test_help_endpoint.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from src.server import create_app
 from src.settings import ServerSettings
 
@@ -9,5 +11,5 @@ def test_help_endpoint_returns_200():
     client = app.test_client()
     resp = client.get("/help")
 
-    assert resp.status_code == 200
+    assert resp.status_code == HTTPStatus.OK
     assert len(resp.data) > 0

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,4 +1,5 @@
 import subprocess
+from http import HTTPStatus
 
 from src.server import create_app
 from src.settings import ServerSettings
@@ -20,5 +21,5 @@ def test_root_returns_200_with_mock(monkeypatch):
     client = app.test_client()
     resp = client.get("/")
 
-    assert resp.status_code == 200
+    assert resp.status_code == HTTPStatus.OK
     assert b"ok" in resp.data


### PR DESCRIPTION
General:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/ryansurf/cli-surf/blob/main/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ryansurf/cli-surf/pulls) for the same update/change?

### Code:

1. [x] Does your submission pass [tests](https://ryansurf.github.io/cli-surf/tests/)?
2. [ ] Have you run the [linter/formatter](https://ryansurf.github.io/cli-surf/styling/) on your code locally before submission?
3. [ ] Have you updated the documentation/README to reflect your changes, as applicable?
4. [x] Have you added an explanation of what your changes do?
5. [x] Have you written new tests for your changes, as applicable?

Related to #16

What:
- Add pytest coverage for /help (and /) using the `create_app` factory

How tested:
- poetry run pytest -q

## Summary by Sourcery

Add test coverage for the root and help HTTP endpoints using the application factory.

Tests:
- Add pytest coverage for the root (/) endpoint validating a 200 response and expected body content.
- Add pytest coverage for the /help endpoint validating a 200 response and non-empty body.