### PR TITLE
Bugfix server crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cli-surf"
-version = "2.5.0"
+version = "2.5.1"
 description = "Command-line surf report tool"
 license = "MIT"
 authors = ["ryansurf <your@email.com>"] # TODO: email

--- a/src/api.py
+++ b/src/api.py
@@ -106,6 +106,8 @@ def get_uv(
 
     # Current values. The order of variables needs to be the same as requested.
     current = response.Current()
+    if current is None:
+        return "No data"
     current_uv_index = round(current.Variables(0).Value(), decimal)
 
     return current_uv_index
@@ -206,6 +208,8 @@ def ocean_information(
 
     # Current values. The order of variables needs to be the same as requested.
     current = response.Current()
+    if current is None:
+        return [0, 0, 0, 0]
     current_wave_height = round(current.Variables(0).Value(), decimal)
     current_wave_direction = round(current.Variables(1).Value(), decimal)
     current_wave_period = round(current.Variables(2).Value(), decimal)
@@ -309,6 +313,8 @@ def current_wind_temp(
 
     # Current values. The order of variables needs to be the same as requested.
     current = response.Current()
+    if current is None:
+        return [0, 0, 0]
     current_temperature = round(current.Variables(0).Value(), decimal)
     current_wind_speed = round(current.Variables(1).Value(), decimal)
     current_wind_direction = round(current.Variables(2).Value(), decimal)

--- a/src/open_meteo.py
+++ b/src/open_meteo.py
@@ -1,18 +1,38 @@
+import sqlite3
+import threading
+
 import openmeteo_requests
 import requests_cache
 from retry_requests import retry
 
+_CACHE_PATH = "/tmp/.cache"
+_thread_local = threading.local()
 
-def _create_client() -> openmeteo_requests.Client:
-    """Creates a cached, retry-enabled Open-Meteo API client."""
+
+def _build_client() -> openmeteo_requests.Client:
     backend = requests_cache.SQLiteCache(
-        "/tmp/.cache", use_memory=False, wal=True
+        _CACHE_PATH, use_memory=False, wal=True
     )
-    cache_session = requests_cache.CachedSession(
-        backend=backend, expire_after=3600
+    session = requests_cache.CachedSession(backend=backend, expire_after=3600)
+    return openmeteo_requests.Client(
+        session=retry(session, retries=5, backoff_factor=0.2)
     )
-    retry_session = retry(cache_session, retries=5, backoff_factor=0.2)
-    return openmeteo_requests.Client(session=retry_session)
 
 
-openmeteo_client = _create_client()
+def _get_thread_client() -> openmeteo_requests.Client:
+    if not hasattr(_thread_local, "client"):
+        _thread_local.client = _build_client()
+    return _thread_local.client
+
+
+class _ResilientClient:
+    def weather_api(self, url, params=None):
+        client = _get_thread_client()
+        try:
+            return client.weather_api(url, params=params)
+        except sqlite3.DatabaseError:
+            _thread_local.client = _build_client()
+            return _thread_local.client.weather_api(url, params=params)
+
+
+openmeteo_client = _ResilientClient()

--- a/src/open_meteo.py
+++ b/src/open_meteo.py
@@ -26,7 +26,8 @@ def _get_thread_client() -> openmeteo_requests.Client:
 
 
 class _ResilientClient:
-    def weather_api(self, url, params=None):
+    @staticmethod
+    def weather_api(url, params=None):
         client = _get_thread_client()
         try:
             return client.weather_api(url, params=params)


### PR DESCRIPTION
General:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/ryansurf/cli-surf/blob/main/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ryansurf/cli-surf/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Code:

1. [ ] Does your submission pass [tests](https://ryansurf.github.io/cli-surf/tests/)?
2. [ ] Have you run the [linter/formatter](https://ryansurf.github.io/cli-surf/styling/) on your code locally before submission?
3. [ ] Have you updated the documentation/README to reflect your changes, as applicable?
4. [ ] Have you added an explanation of what your changes do?
5. [ ] Have you written new tests for your changes, as applicable?

## Summary by Sourcery

Fix server crashes when querying Open-Meteo data by making the HTTP client more resilient and handling empty responses safely.

Bug Fixes:
- Prevent SQLite cache-related crashes by using a thread-local Open-Meteo client and recreating it on database errors.
- Avoid crashes when Open-Meteo returns no current data by safely handling missing current values in UV, ocean, and wind/temperature helpers.

Enhancements:
- Introduce a resilient client wrapper around the Open-Meteo client to centralize error handling for API calls.

Build:
- Bump package version to 2.5.1 to reflect the bugfix release.